### PR TITLE
Return empty list for no results

### DIFF
--- a/Sources/ImageEmboss/Errors.swift
+++ b/Sources/ImageEmboss/Errors.swift
@@ -1,4 +1,4 @@
-public enum Errors: Error {
+public enum ImageEmbossErrors: Error {
     case noResults
     case ciImage
 }

--- a/Sources/ImageEmboss/ImageEmboss.swift
+++ b/Sources/ImageEmboss/ImageEmboss.swift
@@ -21,7 +21,8 @@ public struct ImageEmboss {
         }
                 
         guard let results = req.results!.first else {
-            return .failure(Errors.noResults)
+            // return .failure(ImageEmbossErrors.noResults)
+            return .success([CIImage]())
         }
         
         if combined {


### PR DESCRIPTION
* Return empty list for no results, rather than an error
* Rename `Errors` as `ImageEmbossErrors`
* This release is NOT backwards compatible